### PR TITLE
PM-18: Implement graceful shutdown for HTTP server and add shutdown tests

### DIFF
--- a/cmd/api/shutdown.go
+++ b/cmd/api/shutdown.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+func shutdownServer(srv *http.Server, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		// Escalate: guarantee we stop accepting/serving if graceful shutdown timed out.
+		_ = srv.Close()
+		return err
+	}
+	return nil
+}

--- a/cmd/api/shutdown_test.go
+++ b/cmd/api/shutdown_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestShutdownServer_TimeoutForcesClose(t *testing.T) {
+	started := make(chan struct{})
+	block := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		select {
+		case <-block:
+			w.WriteHeader(http.StatusOK)
+		case <-r.Context().Done():
+			// If the server closes the connection, request ctx is canceled.
+			return
+		}
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Fire request in background
+	done := make(chan error, 1)
+	go func() {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+ln.Addr().String()+"/slow", nil)
+		_, err := client.Do(req)
+		done <- err
+	}()
+
+	<-started // ensure request is running
+
+	// Now shut down with a tiny timeout: should time out and escalate to Close().
+	err = shutdownServer(srv, 50*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected shutdown error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded; got %v", err)
+	}
+
+	// Unblock handler so we don't leak goroutines in the test.
+	close(block)
+
+	// Client should fail because we escalated to Close().
+	if clientErr := <-done; clientErr == nil {
+		t.Fatalf("expected client error after forced close, got nil")
+	}
+}


### PR DESCRIPTION
- Introduced a shutdownServer function to handle graceful server shutdown with a specified timeout.
- Updated main function to listen for shutdown signals and handle server errors appropriately.
- Added shutdown_test.go to test server shutdown behavior under timeout conditions.

Fixes #20

## Summary

What does this change and why?

## Linked Linear Issue

PM-XX

## How to Test

- [ ] `make test`
- [ ] Manual steps:

## Risk

Low / Medium / High

## Checklist

- [ ] Tests added/updated
- [ ] Consistent JSON errors
- [ ] No double logging + returning errors
- [ ] gofmt clean
