### PR TITLE
PM-19: Add health check endpoints and tests

### DIFF
--- a/internal/httpapi/health_endpoints_test.go
+++ b/internal/httpapi/health_endpoints_test.go
@@ -1,0 +1,67 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/linus5304/project-manager-api/internal/store"
+)
+
+type pingStore struct {
+	store.ProjectStore
+	err error
+}
+
+func (ps pingStore) Ping(ctx context.Context) error { return ps.err }
+
+func TestLivez_200(t *testing.T) {
+	app := NewApplication(store.NewMemoryStore())
+	ts := httptest.NewServer(app.Routes())
+	t.Cleanup(ts.Close)
+
+	res, err := http.Get(ts.URL + "/livez")
+	if err != nil {
+		t.Fatalf("GET /livez: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+}
+
+func TestReadyz_200_WithMemoryStore(t *testing.T) {
+	app := NewApplication(store.NewMemoryStore())
+	ts := httptest.NewServer(app.Routes())
+	t.Cleanup(ts.Close)
+
+	res, err := http.Get(ts.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+}
+
+func TestReadyz_503_WhenPingFails(t *testing.T) {
+	base := store.NewMemoryStore()
+	app := NewApplication(pingStore{ProjectStore: base, err: errors.New("db down")})
+	ts := httptest.NewServer(app.Routes())
+	t.Cleanup(ts.Close)
+
+	res, err := http.Get(ts.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", res.StatusCode)
+	}
+}

--- a/internal/httpapi/livez.go
+++ b/internal/httpapi/livez.go
@@ -1,0 +1,7 @@
+package httpapi
+
+import "net/http"
+
+func (app *Application) livez(w http.ResponseWriter, r *http.Request) {
+	_ = writeJSON(w, http.StatusOK, map[string]string{"status": "OK"}, nil)
+}

--- a/internal/httpapi/readyz.go
+++ b/internal/httpapi/readyz.go
@@ -1,0 +1,30 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type pinger interface {
+	Ping(ctx context.Context) error
+}
+
+func (app *Application) readyz(w http.ResponseWriter, r *http.Request) {
+	p, ok := app.store.(pinger)
+	if !ok {
+		// Memorystate (or any store without Ping) => ready
+		_ = writeJSON(w, http.StatusOK, map[string]string{"status": "OK"}, nil)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 250*time.Millisecond)
+	defer cancel()
+
+	if err := p.Ping(ctx); err != nil {
+		_ = writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "not ready"}, nil)
+		return
+	}
+
+	_ = writeJSON(w, http.StatusOK, map[string]string{"status": "OK"}, nil)
+}

--- a/internal/httpapi/routes.go
+++ b/internal/httpapi/routes.go
@@ -14,6 +14,9 @@ func (app *Application) Routes() http.Handler {
 	mux.HandleFunc("GET /v1/projects/{id}/tasks", app.listTasks)
 	mux.HandleFunc("PATCH /v1/projects/{projectId}/tasks/{taskId}", app.updateTask)
 
+	mux.HandleFunc("GET /livez", app.livez)
+	mux.HandleFunc("GET /readyz", app.readyz)
+
 	h := http.Handler(mux)
 	h = app.logRequestMiddleware(h)
 	h = app.recoverPanicMiddleware(h)

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -21,6 +21,10 @@ type PostgresStore struct {
 
 var _ ProjectStore = (*PostgresStore)(nil)
 
+func (s *PostgresStore) Ping(ctx context.Context) error {
+	return s.pool.Ping(ctx)
+}
+
 func NewPostgresStore(ctx context.Context, dsn string) (*PostgresStore, error) {
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {


### PR DESCRIPTION
- Implemented /livez and /readyz endpoints for application health checks.
- Added corresponding tests to verify the functionality of these endpoints.
- Enhanced PostgresStore with a Ping method to support readiness checks.
- Updated routes to include the new health check endpoints.

Fix #22

## Summary

What does this change and why?

## Linked Linear Issue

PM-XX

## How to Test

- [ ] `make test`
- [ ] Manual steps:

## Risk

Low / Medium / High

## Checklist

- [ ] Tests added/updated
- [ ] Consistent JSON errors
- [ ] No double logging + returning errors
- [ ] gofmt clean
